### PR TITLE
Fix AttributeError: climate entity fails to load on current Home Assistant

### DIFF
--- a/custom_components/panasonic_miraie/climate.py
+++ b/custom_components/panasonic_miraie/climate.py
@@ -145,6 +145,7 @@ class PanasonicMirAIeClimate(ClimateEntity):
     _attr_min_temp = 16
     _attr_max_temp = 30
     _attr_hvac_modes = list(HVAC_MODE_MAP.values())
+    _attr_hvac_mode = HVACMode.OFF
     _attr_fan_modes = list(FAN_MODE_MAP.values())
     _attr_swing_modes = list(SWING_MODE_MAP.keys())
     _attr_preset_modes = list(PRESET_MODES.keys())
@@ -433,7 +434,7 @@ class PanasonicMirAIeClimate(ClimateEntity):
             hvac_mode_str = payload.get("acmd")
 
             self._attr_hvac_mode = (
-                self.HVAC_MODE_MAP.get(hvac_mode_str, HVACMode.OFF)
+                HVAC_MODE_MAP.get(hvac_mode_str, HVACMode.OFF)
                 if is_power_on
                 else HVACMode.OFF
             )


### PR DESCRIPTION
## Problem

On current Home Assistant, the climate entity fails to load and the AC is unusable. Two bugs in `climate.py`:

```
ERROR ... custom_components.panasonic_miraie.climate] Error handling state update for PANASONIC AC: 'PanasonicMirAIeClimate' object has no attribute 'HVAC_MODE_MAP'
ERROR ... homeassistant.components.climate] Error adding entity climate.panasonic_ac for domain climate with platform panasonic_miraie
AttributeError: 'PanasonicMirAIeClimate' object has no attribute '_attr_hvac_mode'
```

## Root cause

1. **`self.HVAC_MODE_MAP`** (line ~436) references the module-level `HVAC_MODE_MAP` constant as if it were an instance attribute. It isn't, so every MQTT state update raises `AttributeError`. (Every other use in the file correctly refers to `HVAC_MODE_MAP` without `self.`.)
2. **`_attr_hvac_mode` is never initialized.** The `hvac_mode` property returns `self._attr_hvac_mode`, but it's only ever set inside the state-update handler — which crashes on bug #1. When HA reads the property during entity setup (before the first successful update), it raises `AttributeError` and aborts adding the entity.

## Fix

- Drop the erroneous `self.` so it uses the module-level `HVAC_MODE_MAP`.
- Add a class-level default `_attr_hvac_mode = HVACMode.OFF` next to the existing `_attr_hvac_modes`.

Tested against a live MirAIe AC: the `climate` entity now loads and tracks state correctly (mode, current/target temp, fan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Panasonic MirAIe climate entities now properly initialize HVAC mode to OFF at startup and improve how climate control commands are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->